### PR TITLE
Feat/generate event descriptor during crawl

### DIFF
--- a/cloud/functions/package-lock.json
+++ b/cloud/functions/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.3.6",
         "firebase-admin": "^11.5.0",
         "firebase-functions": "^4.2.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "zod": "3.21.4"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -12136,6 +12137,14 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -21635,6 +21644,11 @@
         "compress-commons": "^4.1.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     }
   }
 }

--- a/cloud/functions/package.json
+++ b/cloud/functions/package.json
@@ -20,7 +20,8 @@
     "axios": "^1.3.6",
     "firebase-admin": "^11.5.0",
     "firebase-functions": "^4.2.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/cloud/functions/package.json
+++ b/cloud/functions/package.json
@@ -4,7 +4,7 @@
     "lint": "eslint --ext .js,.ts .",
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "serve": "npm run build && firebase emulators:start  --import data --export-on-exit",
+    "serve": "npm run build && firebase emulators:start  --import data --export-on-exit --inspect-functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",

--- a/cloud/functions/src/crawlers/crawl-kind.ts
+++ b/cloud/functions/src/crawlers/crawl-kind.ts
@@ -1,0 +1,97 @@
+import {z} from "zod";
+import {FullEvent} from "../models/Event";
+
+export type CrawlerKind<ZOD_TYPE extends z.ZodType> = {
+    kind: string,
+    crawlerImpl: (eventId: string, crawlerDescriptor: z.infer<ZOD_TYPE>) => Promise<FullEvent>,
+    descriptorParser: ZOD_TYPE
+}
+
+export const FIREBASE_CRAWLER_DESCRIPTOR_PARSER = z.object({
+    kind: z.string(),
+    descriptorUrl: z.string(),
+    crawl: z.boolean()
+})
+
+export const FULL_DESCRIPTOR_PARSER = z.object({
+    title: z.string(),
+    headingTitle: z.string(),
+    description: z.string(),
+    days: z.array(z.object({
+        id: z.string(), localDate: z.string().regex(/\d{4}-\d{2}-\d{2}/)
+    })),
+    timezone: z.string(),
+    keywords: z.array(z.string()),
+    location: z.object({
+        country: z.string(), city: z.string()
+    }),
+    features: z.object({
+        roomsDisplayed: z.boolean(),
+        favoritesEnabled: z.boolean(),
+        remindMeOnceVideosAreAvailableEnabled: z.boolean(),
+        hideLanguages: z.array(z.string()),
+        ratings: z.object({
+            bingo: z.object({
+                enabled: z.boolean(),
+                choices: z.array(z.object({
+                    id: z.string(),
+                    label: z.string()
+                }))
+            }),
+            scale: z.object({
+                enabled: z.boolean(),
+                icon: z.enum(['star', 'thumbs-up']),
+                max: z.number()
+            }),
+            'free-text': z.object({
+                enabled: z.boolean(),
+                maxLength: z.number()
+            }),
+            'custom-scale': z.object({
+                enabled: z.boolean(),
+                choices: z.array(z.object({
+                    id: z.string(),
+                    icon: z.enum(['smiling_face', 'neutral_face', 'confused_face'])
+                }))
+            })
+        })
+    }),
+    supportedTalkLanguages: z.array(z.object({
+        id: z.string(),
+        label: z.string(),
+        themeColor: z.string()
+    })),
+    talkFormats: z.array(z.object({
+        id: z.string(),
+        title: z.string(),
+        duration: z.string().regex(/PT\d+m/),
+        themeColor: z.string(),
+    })),
+    talkTracks: z.array(z.object({
+        id: z.string(),
+        title: z.string(),
+        themeColor: z.string()
+    })),
+    rooms: z.array(z.object({
+        id: z.string(),
+        title: z.string()
+    })),
+    theming: z.object({
+        colors: z.object({
+            primaryHex: z.string(),
+            primaryContrastHex: z.string(),
+            secondaryHex: z.string(),
+            secondaryContrastHex: z.string(),
+            tertiaryHex: z.string(),
+            tertiaryContrastHex: z.string(),
+        })
+    }),
+    infos: z.object({
+        venuePicture: z.string(),
+        eventDescription: z.string()
+    }),
+    logoUrl: z.string(),
+    backgroundUrl: z.string(),
+    websiteUrl: z.string(),
+    peopleDescription: z.string().nullable(),
+})

--- a/cloud/functions/src/crawlers/crawl.ts
+++ b/cloud/functions/src/crawlers/crawl.ts
@@ -3,6 +3,7 @@ import {crawl as crawlDevoxx, DEVOXX_DESCRIPTOR_PARSER} from "./devoxx/crawler"
 import { FullEvent } from "../models/Event";
 import {FIREBASE_CRAWLER_DESCRIPTOR_PARSER, CrawlerKind} from "./crawl-kind";
 import {z} from "zod";
+const axios = require('axios');
 
 
 const CRAWLERS: CrawlerKind<z.ZodType>[] = [
@@ -31,7 +32,7 @@ const crawlAll = async function() {
                 }
 
                 info(`crawling event ${doc.id} of type [${firebaseCrawlerDescriptor.kind}]...`)
-                const crawlerDescriptorContent = await fetch(firebaseCrawlerDescriptor.descriptorUrl).then(resp => resp.json());
+                const crawlerDescriptorContent = (await axios.get(firebaseCrawlerDescriptor.descriptorUrl)).data
                 const crawlerKindDescriptor = crawler.descriptorParser.parse(crawlerDescriptorContent);
 
                 const event = await crawler.crawlerImpl(doc.id, crawlerKindDescriptor);

--- a/cloud/functions/src/crawlers/crawl.ts
+++ b/cloud/functions/src/crawlers/crawl.ts
@@ -77,6 +77,10 @@ const saveEvent = async function(event: FullEvent) {
                 .set(talkStatWithDay.stat)
         })
     )
+
+    await firestoreEvent.collection('event-descriptor')
+        .doc('self')
+        .set(event.conferenceDescriptor);
 }
 
 export default crawlAll;

--- a/cloud/functions/src/crawlers/devoxx/crawler.ts
+++ b/cloud/functions/src/crawlers/devoxx/crawler.ts
@@ -19,8 +19,10 @@ const daysOfWeek = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'sat
 export const DEVOXX_DESCRIPTOR_PARSER = FULL_DESCRIPTOR_PARSER.omit({
     // All these fields can be extracted from the devoxx API
     title: true, description: true, days: true,
-    timezone: true, location: true, talkFormats: true,
-    rooms: true,
+    timezone: true, location: true,
+    // We're not putting tracks here even though we can get them from devoxx API
+    // because we need a theme color for them that are currently *not* provided by the API
+    talkFormats: true, rooms: true,
 })
 
 export const crawl = async (eventId: string, descriptor: z.infer<typeof DEVOXX_DESCRIPTOR_PARSER>) => {

--- a/cloud/functions/src/crawlers/devoxx/crawler.ts
+++ b/cloud/functions/src/crawlers/devoxx/crawler.ts
@@ -56,14 +56,14 @@ export const crawl = async (eventId:string) => {
       } as ListableEvent
 
     const event: FullEvent = { id: eventId, info: eventInfo, daySchedules: [], talkStats: [], talks: []}
-    for (const day of days) {
+    await Promise.all(days.map(async day => {
         const {daySchedule, talkStats, talks} = await crawlDevoxxDay(eventId, day.id)
-        event.daySchedules.push(daySchedule)        
+        event.daySchedules.push(daySchedule)
         event.talkStats.push({day: day.id, stats: talkStats})
         for (const talk of talks) {
             event.talks.push(talk)
         }
-    }
+    }))
     return event
 }
 

--- a/cloud/functions/src/firebase.ts
+++ b/cloud/functions/src/firebase.ts
@@ -6,6 +6,10 @@ export const info = function(msg:string) {
     logger.info(msg, {structuredData: true})
 }
 
+export const error = function(msg:string) {
+    logger.error(msg, {structuredData: true})
+}
+
 initializeApp();
 
 export const db = getFirestore();

--- a/cloud/functions/src/models/Event.ts
+++ b/cloud/functions/src/models/Event.ts
@@ -1,9 +1,11 @@
 import { ListableEvent } from "../../../../shared/event-list.firestore";
 import { DayTalksStats } from "../../../../shared/feedbacks.firestore";
 import { DailySchedule, Talk } from "../../../../shared/dayly-schedule.firestore";
+import {ConferenceDescriptor} from "../../../../shared/conference-descriptor.firestore";
 
 export interface FullEvent {
     id: string,
+    conferenceDescriptor: ConferenceDescriptor,
     info: ListableEvent,
     daySchedules: DailySchedule[],
     talkStats: DayTalksStats[],


### PR DESCRIPTION
Idea behind this PR is to introduce Event Descriptors created by crawlers in firestore.

### Changes in firestore

**/crawlers/devoxx/*** : has to be removed

**/crawlers/:eventId** : new entries describing crawlers and looking like : 
```
{
    "crawl": true,
    "kind": "devoxx",
    "descriptorUrl": "https://gist.githubusercontent.com/fcamblor/9947fc134714855116c2afd8c1856303/raw/5158b080845ab2ebde215501069ad109e61cc48b/voxxrin3-devoxxuk23-crawler-descriptor.json"
}
```

`descriptorUrl` is supposed to target a json configuration managed by conference organizer, and which is going to be loaded by the crawlers.

Depending on the crawler's `kind`, structure of `descriptorUrl` will have to be different, depending on if Organizer's API can automatically provide (or not) every fields required by Voxxrin event descriptors.

_(I already filled crawler configurations on voxxrin-v3-poc instance)_

**/events/:eventId/event-descriptor/self** : the descriptor which is used in voxxrin


### Things to note

`zod` dependency has been introduced in order to "validate" JSON files provided by conference organizers, in order to enforce its content and/or detect missing mandatory fields in it

I currently deployed new crawler implementation on `voxxrin-v3-poc` firebase instance, and ran it so that we get valid event-descriptors in firestore.