### PR TITLE
Theme uniformization on feedbacks/watch later

### DIFF
--- a/mobile/src/components/talk-card/ScheduleTalk.vue
+++ b/mobile/src/components/talk-card/ScheduleTalk.vue
@@ -407,9 +407,9 @@ const theme = {
     //* Change style type actions *//
     ion-button {
       &.btn-watchLater {
-        --background: var(--voxxrin-event-theme-colors-secondary-hex);
-        --color: var(--voxxrin-event-theme-colors-secondary-contrast-hex);
-        border-left: 1px solid var(--voxxrin-event-theme-colors-secondary-hex);
+        --background: var(--voxxrin-event-theme-colors-tertiary-hex);
+        --color: var(--voxxrin-event-theme-colors-tertiary-contrast-hex);
+        border-left: 1px solid var(--voxxrin-event-theme-colors-tertiary-hex);
       }
 
       &.btn-feedbackSelect {
@@ -455,7 +455,7 @@ const theme = {
 
     &._has-to-watch-later {
       &:before {
-        background: linear-gradient(331deg, rgba(var(--voxxrin-event-theme-colors-secondary-rgb), 0.6) 30%, rgba(var(--voxxrin-event-theme-colors-primary-rgb), 0.6) 80%) !important;
+        background: linear-gradient(331deg, rgba(var(--voxxrin-event-theme-colors-tertiary-rgb), 0.6) 30%, rgba(var(--voxxrin-event-theme-colors-primary-rgb), 0.6) 80%) !important;
       }
     }
   }

--- a/mobile/src/components/talk-card/TalkSelectForFeedback.vue
+++ b/mobile/src/components/talk-card/TalkSelectForFeedback.vue
@@ -24,9 +24,9 @@ const props = defineProps({
   font-size: 22px;
 
   &._is-active {
-    --background: var(--ion-color-primary);
-    --color: var(--voxxrin-event-theme-colors-secondary-tertiary-hex);
-    border-left: 1px solid var(--voxxrin-event-theme-colors-tertiary-hex);
+    --background: var(--voxxrin-event-theme-colors-secondary-hex);
+    --color: var(--voxxrin-event-theme-colors-secondary-hex);
+    border-left: 1px solid var(--voxxrin-event-theme-colors-secondary-hex);
     color: white;
 
     @media (prefers-color-scheme: dark) {

--- a/mobile/src/components/talk-card/TalkWatchLaterButton.vue
+++ b/mobile/src/components/talk-card/TalkWatchLaterButton.vue
@@ -55,9 +55,9 @@ defineExpose({
 .btn-watchLater {
 
   &._is-active {
-    --background: var(--voxxrin-event-theme-colors-secondary-hex);
-    --color: var(--voxxrin-event-theme-colors-secondary-contrast-hex);
-    border-left: 1px solid var(--voxxrin-event-theme-colors-secondary-hex);
+    --background: var(--voxxrin-event-theme-colors-tertiary-hex);
+    --color: var(--voxxrin-event-theme-colors-tertiary-contrast-hex);
+    border-left: 1px solid var(--voxxrin-event-theme-colors-tertiary-hex);
   }
 }
 </style>

--- a/mobile/src/views/feedbacks/NewFeedbackPage.vue
+++ b/mobile/src/views/feedbacks/NewFeedbackPage.vue
@@ -91,11 +91,9 @@
                 <small>({{ LL.During_this_time_slot() }})</small>
             </span>
         </ion-button>
-        <ion-button size="small" fill="solid" shape="round" expand="block" v-if="selectedTalk !== undefined" @click="rateSelectedTalk()"
+        <ion-button class="add-feedback-btn" size="small" fill="solid" shape="round" expand="block" v-if="selectedTalk !== undefined" @click="rateSelectedTalk()"
                     :aria-label="LL.Add_Feedback()">
-            <span class="contentDidntAttendTalk">
               {{LL.Add_Feedback()}}
-            </span>
         </ion-button>
       </template>
     </feedback-footer>
@@ -241,7 +239,7 @@ function updateFeedbackSelectorRefTo(timeslotId: ScheduleTimeSlotId|undefined, f
     justify-content: space-between;
     row-gap: 4px;
     padding: 8px 16px;
-    background: var(--app-primary);
+    background: var(--voxxrin-event-theme-colors-secondary-hex);
     color: white;
     z-index: 1;
 
@@ -277,7 +275,7 @@ function updateFeedbackSelectorRefTo(timeslotId: ScheduleTimeSlotId|undefined, f
       border-radius: 0 0 0 8px;
       padding: 4px 12px;
       font-size: 12px;
-      background-color: var(--app-primary);
+      background-color: var(--voxxrin-event-theme-colors-secondary-hex);
       z-index: 1;
 
       @media (prefers-color-scheme: dark) {
@@ -290,5 +288,9 @@ function updateFeedbackSelectorRefTo(timeslotId: ScheduleTimeSlotId|undefined, f
     display: inline-flex;
     flex-direction: column;
     row-gap: 2px;
+  }
+
+  .add-feedback-btn {
+    --background: var(--voxxrin-event-theme-colors-secondary-hex)
   }
 </style>

--- a/mobile/src/views/feedbacks/RateTalkPage.vue
+++ b/mobile/src/views/feedbacks/RateTalkPage.vue
@@ -200,7 +200,7 @@ function backToSchedulePage() {
   display: flex;
   flex-direction: column;
   min-height: 100%;
-  background: var(--app-primary);
+  background: var(--voxxrin-event-theme-colors-secondary-hex);
 
   &-head {
     position: sticky;


### PR DESCRIPTION
Objective of this PR is to uniformize theme for feedbacks & watch-later button : 
- secondary color used for feedbacks everywhere
- tertiary color used for watch-later everywhere

Impacts : 
- On schedule/favorites page, watch later button is now using tertiary instead of secondary (which is reserved for feedbacks), with impact on the talk card "spray"

| Before | After |
| ------- | ----------- |
| <img width="300" alt="Cursor_and_Voxxrin" src="https://github.com/voxxrin/voxxrin3/assets/603815/dd0050ff-c78d-4f8b-9adb-de4c640fdac5"> | <img width="300" alt="Cursor_and_Voxxrin" src="https://github.com/voxxrin/voxxrin3/assets/603815/0c7a7213-55ce-46a1-8909-64246386c454"> |

- On Talk Feedback selector, header should be using secondary instead of tertiary + same changes than before on talk card's spray / watch-later button 

| Before | After |
| ------- | ----------- |
| <img width="300" alt="Cursor_and_Voxxrin" src="https://github.com/voxxrin/voxxrin3/assets/603815/084af027-4c0f-4353-984c-146dda4d36f3"> | <img width="300" alt="Cursor_and_Voxxrin" src="https://github.com/voxxrin/voxxrin3/assets/603815/a41e7b5d-621c-46f6-a958-d79e7b2793f3"> |
| <img width="300" alt="Cursor_and_Voxxrin" src="https://github.com/voxxrin/voxxrin3/assets/603815/61ecdfd8-e496-45b2-87b7-ef423e58703c"> | <img width="300" alt="Cursor_and_Voxxrin" src="https://github.com/voxxrin/voxxrin3/assets/603815/9bbcffb1-1339-43e0-9f08-ac7a8156002d"> |